### PR TITLE
Update HelioWebXRPolyfill.

### DIFF
--- a/js/three/examples/jsm/vr/HelioWebXRPolyfill.js
+++ b/js/three/examples/jsm/vr/HelioWebXRPolyfill.js
@@ -2,184 +2,42 @@
  * @author mvilledieu / http://github.com/mvilledieu
  */
 
-if ( /(Helio)/g.test( navigator.userAgent ) && "xr" in navigator ) {
+if ( /(Helio)/g.test( navigator.userAgent ) && 'xr' in navigator ) {
 
-	console.log( "Helio WebXR Polyfill (Lumin 0.97.0)" );
+	console.log( "Helio WebXR Polyfill (Lumin 0.98.0)" );
 
-	const isHelio96 = navigator.userAgent.includes("Chrome/73");
+	if ( 'isSessionSupported' in navigator.xr ) {
 
-	// WebXRManager - XR.supportSession() Polyfill - WebVR.js line 147
+		const tempIsSessionSupported = navigator.xr.isSessionSupported.bind( navigator.xr );
 
-	if (
-		"supportsSession" in navigator.xr === false &&
-    "supportsSessionMode" in navigator.xr
-	) {
-
-		navigator.xr.supportsSession = function ( sessionType ) {
+		navigator.xr.isSessionSupported = function ( /*sessionType*/ ) {
 
 			// Force using immersive-ar
-			return navigator.xr.supportsSessionMode( 'immersive-ar' );
+			return tempIsSessionSupported( 'immersive-ar' );
 
 		};
 
 	}
 
-	if ( "requestSession" in navigator.xr ) {
+	if ( 'isSessionSupported' in navigator.xr && 'requestSession' in navigator.xr ) {
 
 		const tempRequestSession = navigator.xr.requestSession.bind( navigator.xr );
 
-		navigator.xr.requestSession = function ( sessionType ) {
+		navigator.xr.requestSession = function ( /*sessionType*/ ) {
 
 			return new Promise( function ( resolve, reject ) {
 
-				const sessionType = (isHelio96 ? {
-					mode: 'immersive-ar' // Force using immersive-ar
-				} : 'immersive-ar');
+				var sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor' ] };
 
-				tempRequestSession( sessionType )
-					.then( function ( session ) {
+				tempRequestSession( 'immersive-ar', sessionInit ).then( function ( session ) {
 
-						// WebXRManager - xrFrame.getPose() Polyfill - line 279
+					resolve( session );
 
-						const tempRequestAnimationFrame = session.requestAnimationFrame.bind(
-							session
-						);
+				} ).catch( function ( error ) {
 
-						session.requestAnimationFrame = function ( callback ) {
+					return reject( error );
 
-							return tempRequestAnimationFrame( function ( time, frame ) {
-
-								// WebXRManager - xrFrame.getViewerPose() Polyfill - line 279
-								// Transforms view.viewMatrix to view.transform.inverse.matrix
-
-								const tempGetViewerPose = frame.getViewerPose.bind( frame );
-
-								frame.getViewerPose = function ( referenceSpace ) {
-
-									const pose = tempGetViewerPose( referenceSpace );
-
-									pose.views.forEach( function ( view ) {
-
-										view.transform = {
-											inverse: {
-												matrix: view.viewMatrix
-											}
-										};
-
-									} );
-
-									return pose;
-
-								};
-
-								// WebXRManager - xrFrame.getPose() Polyfill - line 259
-
-								const tempGetPose = (isHelio96 ? null : frame.getPose.bind( frame ));
-
-								frame.getPose = function ( targetRaySpace, referenceSpace ) {
-
-									if (isHelio96) {
-
-										const inputPose = frame.getInputPose(
-											targetRaySpace,
-											referenceSpace
-										);
-
-										inputPose.transform = {
-											matrix: inputPose.targetRay.transformMatrix
-										};
-
-										return inputPose;
-
-									} else {
-
-										return tempGetPose(targetRaySpace.gripSpace, referenceSpace);
-
-									}
-
-								};
-
-								callback( time, frame );
-
-							} );
-
-						};
-
-						// WebXRManager - xrFrame.getPose( inputSource.targetRaySpace, referenceSpace) Polyfill - line 279
-
-						const tempGetInputSources = session.getInputSources.bind( session );
-
-						session.getInputSources = function () {
-
-							const res = tempGetInputSources();
-
-							res.forEach( function (xrInputSource ) {
-
-								Object.defineProperty( xrInputSource, "targetRaySpace", {
-									get: function () {
-
-										return xrInputSource;
-
-									}
-								} );
-
-							} );
-
-							return res;
-
-						};
-
-						// WebXRManager - xrSession.getInputSources() Polyfill Line 132 - 136
-
-						session.inputSources = Object.defineProperty(
-							session,
-							"inputSources",
-							{
-								get: session.getInputSources
-							}
-						);
-
-						// WebXRManager - xrSession.updateRenderState() Polyfill Line 129
-
-						if (isHelio96) {
-
-							session.updateRenderState = function ( { baseLayer } ) {
-
-								session.baseLayer = baseLayer;
-
-								// WebXRManager - xrSession.renderState.baseLayer Polyfill Line 219
-
-								session.renderState = {
-									baseLayer: baseLayer
-								};
-
-							};
-
-						}
-
-						// WebXRManager - xrSession.requestReferenceSpace() Polyfill Line 130
-
-						const tempRequestReferenceSpace = session.requestReferenceSpace.bind(
-							session
-						);
-
-						session.requestReferenceSpace = function () {
-
-							return tempRequestReferenceSpace( {
-								type: "stationary",
-								subtype: "floor-level"
-							} );
-
-						};
-
-						resolve( session );
-
-					} )
-					.catch( function ( error ) {
-
-						return reject( error );
-
-					} );
+				} );
 
 			} );
 


### PR DESCRIPTION
This example is refered in https://immersiveweb.dev/, and we notice that it's using outdated HelioWebXRPolyfill.js file, so cannot be properly opened in Helio. This PR updates the polyfill so that it can work on Magic Leap Helio 0.98.